### PR TITLE
Preventing elasticsearch from auto-start

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /tmp/* /var/tmp/*
 
+ADD default-attribute.rb /opt/graylog/embedded/cookbooks/graylog/attributes/default.rb
+
 VOLUME /var/opt/graylog/data
 VOLUME /var/log/graylog
 VOLUME /opt/graylog/plugin

--- a/docker/default-attribute.rb
+++ b/docker/default-attribute.rb
@@ -1,0 +1,105 @@
+default['graylog']['bootstrap']['enable'] = true
+default['graylog']['install_directory'] = "/opt/graylog"
+default['graylog']['var_directory'] = "/var/opt/graylog"
+default['graylog']['authorized_ports'] = [514]
+default['graylog']['timezone'] = "Etc/UTC"
+default['graylog']['smtp_server'] = false
+default['graylog']['smtp_port'] = 587
+default['graylog']['smtp_user'] = false
+default['graylog']['smtp_password'] = false
+default['graylog']['rotation_size'] = 1073741824
+default['graylog']['rotation_time'] = 0
+default['graylog']['indices'] = 10
+default['graylog']['journal_size'] = 1
+
+default['graylog']['user']['username'] = "graylog"
+default['graylog']['user']['group'] = "graylog"
+default['graylog']['user']['uid'] = nil
+default['graylog']['user']['gid'] = nil
+default['graylog']['user']['shell'] = "/bin/sh"
+default['graylog']['user']['home'] = "/var/opt/graylog"
+default['graylog']['user']['git_user_name'] = "Graylog"
+default['graylog']['user']['git_user_email'] = "graylog@#{node['fqdn']}"
+
+default['graylog']['elasticsearch']['enable'] = false
+default['graylog']['elasticsearch']['memory'] = nil # defaults to 60% of VM memory
+default['graylog']['elasticsearch']['log_directory'] = "/var/log/graylog/elasticsearch"
+default['graylog']['elasticsearch']['data_directory'] = "/var/opt/graylog/data/elasticsearch"
+default['graylog']['elasticsearch']['cluster_name'] = "graylog2"
+default['graylog']['elasticsearch']['discovery_zen_ping_timeout'] = "10s"
+
+default['graylog']['mongodb']['enable'] = true
+default['graylog']['mongodb']['log_directory'] = "/var/log/graylog/mongodb"
+default['graylog']['mongodb']['data_directory'] = "/var/opt/graylog/data/mongodb"
+
+default['graylog']['nginx']['enable'] = true
+default['graylog']['nginx']['user'] = "root"
+default['graylog']['nginx']['log_directory'] = "/var/log/graylog/nginx"
+default['graylog']['nginx']['ssl_country_name'] = "DE"
+default['graylog']['nginx']['ssl_state_name'] = "Hamburg"
+default['graylog']['nginx']['ssl_locality_name'] = "Hamburg"
+default['graylog']['nginx']['ssl_company_name'] = "Graylog"
+default['graylog']['nginx']['ssl_organizational_unit_name'] = "Operations"
+default['graylog']['nginx']['server_name'] = node['fqdn']
+default['graylog']['nginx']['ssl_email_address'] = "graylog@#{node['fqdn']}"
+default['graylog']['nginx']['ssl_protocols'] = "TLSv1 TLSv1.1 TLSv1.2"
+default['graylog']['nginx']['ssl_ciphers'] = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA"
+
+default['graylog']['etcd']['enable'] = true
+default['graylog']['etcd']['log_directory'] = "/var/log/graylog/etcd"
+default['graylog']['etcd']['data_directory'] = "/var/opt/graylog/data/etcd"
+
+default['graylog']['graylog-server']['enable'] = true
+default['graylog']['graylog-server']['memory'] = "1500m"
+default['graylog']['graylog-server']['log_directory'] = "/var/log/graylog/server"
+default['graylog']['graylog-server']['journal_directory'] = "/var/opt/graylog/data/journal"
+default['graylog']['graylog-server']['node_id'] = "/var/opt/graylog/graylog-server-node-id"
+default['graylog']['graylog-server']['wrapper'] = "/opt/graylog/embedded/bin/authbind"
+default['graylog']['graylog-server']['plugin_dir'] = "/opt/graylog/plugin"
+default['graylog']['graylog-server']['rest_listen_uri'] = "http://0.0.0.0:12900/"
+default['graylog']['graylog-server']['retention_strategy'] = "delete"
+default['graylog']['graylog-server']['elasticsearch_shards'] = 4
+default['graylog']['graylog-server']['elasticsearch_replicas'] = 1
+default['graylog']['graylog-server']['elasticsearch_index_prefix'] = "graylog"
+default['graylog']['graylog-server']['allow_leading_wildcard_searches'] = true
+default['graylog']['graylog-server']['allow_highlighting'] = false
+default['graylog']['graylog-server']['elasticsearch_cluster_name'] = "graylog2"
+default['graylog']['graylog-server']['elasticsearch_http_enabled'] = false
+default['graylog']['graylog-server']['elasticsearch_cluster_discovery_timeout'] = 5000
+default['graylog']['graylog-server']['elasticsearch_discovery_initial_state_timeout'] = "3s"
+default['graylog']['graylog-server']['elasticsearch_analyzer'] = "standard"
+default['graylog']['graylog-server']['output_batch_size'] = 500
+default['graylog']['graylog-server']['output_flush_interval'] = 1
+default['graylog']['graylog-server']['output_fault_count_threshold'] = 5
+default['graylog']['graylog-server']['output_fault_penalty_seconds'] = 30
+default['graylog']['graylog-server']['processbuffer_processors'] = 5
+default['graylog']['graylog-server']['outputbuffer_processors'] = 3
+default['graylog']['graylog-server']['processor_wait_strategy'] = "blocking"
+default['graylog']['graylog-server']['ring_size'] = 65536
+default['graylog']['graylog-server']['inputbuffer_ring_size'] = 65536
+default['graylog']['graylog-server']['inputbuffer_processors'] = 2
+default['graylog']['graylog-server']['inputbuffer_wait_strategy'] = "blocking"
+default['graylog']['graylog-server']['message_journal_enabled'] = true
+default['graylog']['graylog-server']['async_eventbus_processors'] = 2
+default['graylog']['graylog-server']['dead_letters_enabled'] = false
+default['graylog']['graylog-server']['lb_recognition_period_seconds'] = 3
+default['graylog']['graylog-server']['alert_check_interval'] = 60
+default['graylog']['graylog-server']['rules_file'] = nil
+default['graylog']['graylog-server']['dashboard_widget_default_cache_time'] = "10s"
+
+default['graylog']['graylog-web']['enable'] = true
+default['graylog']['graylog-web']['log_directory'] = "/var/log/graylog/web"
+default['graylog']['graylog-web']['port'] = 9000
+default['graylog']['graylog-web']['bind'] = "0.0.0.0"
+
+default['graylog']['logging']['svlogd_size'] = 200 * 1024 * 1024 # rotate after 200 MB of log data
+default['graylog']['logging']['svlogd_num'] = 30 # keep 30 rotated log files
+default['graylog']['logging']['svlogd_timeout'] = 24 * 60 * 60 # rotate after 24 hours
+default['graylog']['logging']['svlogd_filter'] = "gzip" # compress logs with gzip
+default['graylog']['logging']['svlogd_udp'] = nil # transmit log messages via UDP
+default['graylog']['logging']['svlogd_prefix'] = nil # custom prefix for log messages
+default['graylog']['logging']['udp_log_shipping_host'] = nil # remote host to ship log messages to via UDP
+default['graylog']['logging']['udp_log_shipping_port'] = 514 # remote host to ship log messages to via UDP
+
+default['graylog']['nginx']['svlogd_size'] = 100 * 1024 * 1024 # rotate after 100 MB of log data
+default['graylog']['nginx']['svlogd_num'] = 5 # reduced backlog for nginx


### PR DESCRIPTION
# What's this PR do?

Preventing internal Elasticsearch in Graylog container from starting so it won't join the cluster of Elasticsearch cloud service.
# Where should the reviewer start?

There is a value in a config file that by default will start elasticsearch during container initial startup. Changing that value to "false" would prevent the service from starting.
https://github.com/sekka1/graylog2-images/blob/develop/docker/default-attribute.rb#L24 

The file will be added into the image via Dockerfile.
https://github.com/sekka1/graylog2-images/blob/develop/docker/Dockerfile#L18
# How should this be manually tested?
1. Build the Graylog image using this Dockerfile.
2. Run a container from this image. Look for below messages in the terminal:
   
   ```
   INFO  [IndexerSetupService] Checking Elasticsearch HTTP API at http://127.0.0.1:9200/
   ERROR [IndexerSetupService] Could not connect to Elasticsearch: Connection refused
   WARN  [IndexerSetupService] Could not connect to Elasticsearch
   ```
3. Go to web/ui and check the status of elasticsearch cluster
4. To test if the container will make connection to an external elasticsearch, you can run an elasticsearch docker container from this repo https://github.com/docker-library/elasticsearch/tree/master/1.7
5. Run the container this way:
   
   ```
   docker run -d -p 9200:9200 -p 9300:9300 elasticsearch:1.7 \
   elasticsearch -Des.cluster.name=graylog2 \
   elasticsearch -Des.node.name=elasticsearch1
   ```
6. Check the logs from Graylog container and make sure the new elasticsearch container is detected as master.
   
   ```
   2015-11-05_23:12:25.04046 INFO  [service] [graylog2-server] detected_master [elasticsearch1][VcNvmpJiRJ2mYnNlH_JHQQ][996e13f8d750][inet[/10.20.33.165:9300]], added {[elasticsearch1][VcNvmpJiRJ2mYnNlH_JHQQ][996e13f8d750][inet[/10.20.33.165:9300]],}, reason: zen-disco-receive(from master [[elasticsearch1][VcNvmpJiRJ2mYnNlH_JHQQ][996e13f8d750][inet[/10.20.33.165:9300]]])
   ```
